### PR TITLE
Switches to `shutil.get_terminal_size`

### DIFF
--- a/render50
+++ b/render50
@@ -381,13 +381,7 @@ def concatenate(output, inputs):
 
 def cprint(text="", color=None, on_color=None, attrs=None, end="\n"):
     """Colorize text (and wraps to terminal's width)."""
-
-    # Assume 80 in case not running in a terminal
-    columns, _ = get_terminal_size_fallback()
-    if columns == 0:
-        columns = 80
-
-    # Print text, flushing output
+    columns, _ = shutil.get_terminal_size()
     termcolor.cprint(fill(text, columns, drop_whitespace=False, replace_whitespace=False),
                      color=color, on_color=on_color, attrs=attrs, end=end)
     sys.stdout.flush()
@@ -442,16 +436,6 @@ def get(file):
                 raise RuntimeError("Could not find {}.".format(file))
             else:
                 raise RuntimeError("Could not read {}.".format(file))
-
-
-def get_terminal_size_fallback():
-    try:
-        # Attempt to get terminal size
-        columns, _ = os.get_terminal_size()
-    except OSError:
-        # Fallback to default size if running in a non-terminal environment
-        columns, _ = shutil.get_terminal_size(fallback=(80, 20))
-    return columns
 
 
 def join(a, b):


### PR DESCRIPTION
Docs recommend using `shutil.get_terminal_size` rather than `os.get_terminal_size`.

> `shutil.get_terminal_size()` is the high-level function which should normally be used, os.get_terminal_size is the low-level implementation.

* https://docs.python.org/3/library/os.html#os.get_terminal_size
* https://docs.python.org/3/library/shutil.html#querying-the-size-of-the-output-terminal