### PR TITLE
Fixes side-by-side mode when second file is longer

### DIFF
--- a/render50
+++ b/render50
@@ -23,7 +23,7 @@ from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_for_filename, guess_lexer
 from pygments.lexers.special import TextLexer
 from pygments.styles import get_all_styles
-from pypdf import PdfReader, PdfWriter, Transformation
+from pypdf import PageObject, PdfReader, PdfWriter, Transformation
 from requests.exceptions import RequestException
 from tempfile import mkstemp
 from textwrap import fill
@@ -266,7 +266,7 @@ def main():
         height = int(document.pages[0].height)
         size = "{}px {}px".format(width, height)
 
-        # temporary files
+        # Temporary files
         temps = []
 
         # Render first input
@@ -343,12 +343,6 @@ def concatenate(output, inputs):
     # Read files
     readers = list(map(PdfReader, inputs))
 
-    # Render blank page, inferring size from first input's first page
-    temp = mkstemp()
-    size = "{}pt {}pt".format(readers[0].pages[0].mediabox[2], readers[0].pages[0].mediabox[3])
-    write(temp[1], [blank(size)], False)
-    page = PdfReader(temp[1]).pages[0]
-
     # Concatenate files side by side
     writer = PdfWriter()
 
@@ -356,7 +350,10 @@ def concatenate(output, inputs):
     for i in range(max(map(lambda r: len(r.pages), readers))):
 
         # Leftmost page
-        left = copy(readers[0].pages[i]) if i < len(readers[0].pages) else copy(page)
+        if i < len(readers[0].pages):
+            left = copy(readers[0].pages[i])
+        else:
+            left = PageObject.create_blank_page(width=readers[0].pages[0].mediabox[2], height=readers[0].pages[0].mediabox[3])
 
         # Rotate page
         # https://github.com/py-pdf/pypdf/issues/2139#issuecomment-1702462468
@@ -365,7 +362,10 @@ def concatenate(output, inputs):
 
         # Rightmost pages
         for reader in readers[1:]:
-            right = copy(reader.pages[i]) if i < len(reader.pages) else copy(page)
+            if i < len(reader.pages):
+                right = copy(reader.pages[i])
+            else:
+                right = PageObject.create_blank_page(width=readers[0].pages[0].mediabox[2], height=readers[0].pages[0].mediabox[3])
             left.merge_transformed_page(right, Transformation().translate(left.mediabox[2], 0), expand=True)
 
         # Add pages to output
@@ -374,9 +374,6 @@ def concatenate(output, inputs):
     # Ouput PDF
     with open(output, "wb") as file:
         writer.write(file)
-
-    # Remove temporary files
-    os.close(temp[0]), os.remove(temp[1])
 
 
 def cprint(text="", color=None, on_color=None, attrs=None, end="\n"):

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     python_requires=">=3.9",
     scripts=["render50"],
     url="https://github.com/cs50/render50",
-    version="9.2.8"
+    version="9.2.9"
 )


### PR DESCRIPTION
Fixes #98, using https://pypdf.readthedocs.io/en/latest/modules/PageObject.html#pypdf._page.PageObject.create_blank_page instead of our own code for creating a blank page.